### PR TITLE
Fix determined audio format

### DIFF
--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioTrackTranscoder.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioTrackTranscoder.java
@@ -79,7 +79,7 @@ public class AudioTrackTranscoder implements TrackTranscoder {
 
     @Override
     public MediaFormat getDeterminedFormat() {
-        return mInputFormat;
+        return mActualOutputFormat;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- fix bug in AudioTrackTranscoder `getDeterminedFormat`
- it now returns the actual output format instead of the input one

## Testing
- `./gradlew test` *(fails: Could not determine java version)*

------
https://chatgpt.com/codex/tasks/task_e_6841a16fd4688321957718cc0ad36853